### PR TITLE
Fixing whitespace issues with code blocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '4.0.0'
 gem 'pg'
 
 # Assets
-gem 'haml-rails', '~> 0.4'
+gem 'haml-rails', '~> 0.5.1'
 gem 'sass-rails'
 gem 'compass-rails', '~> 2.0.alpha.0'
 gem 'coffee-rails'
@@ -40,7 +40,7 @@ gem "mini_magick", "~> 3.6.0"
 gem "fog", "~> 1.15.0"
 
 group :assets, :development, :test do
-  gem "haml-rails", "~> 0.4"
+  gem "haml-rails", "~> 0.5.1"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,13 +67,13 @@ GEM
       ruby-hmac
     formatador (0.2.4)
     fssm (0.2.10)
-    haml (4.0.3)
+    haml (4.0.4)
       tilt
-    haml-rails (0.4)
-      actionpack (>= 3.1, < 4.1)
-      activesupport (>= 3.1, < 4.1)
-      haml (>= 3.1, < 4.1)
-      railties (>= 3.1, < 4.1)
+    haml-rails (0.5.1)
+      actionpack (~> 4.0.0)
+      activesupport (~> 4.0.0)
+      haml (>= 3.1, < 5.0)
+      railties (~> 4.0.0)
     hike (1.2.3)
     httpauth (0.2.0)
     i18n (0.6.5)
@@ -196,7 +196,7 @@ DEPENDENCIES
   coffee-rails
   compass-rails (~> 2.0.alpha.0)
   fog (~> 1.15.0)
-  haml-rails (~> 0.4)
+  haml-rails (~> 0.5.1)
   jbuilder (~> 1.2)
   jquery-rails
   kaminari (~> 0.14.1)

--- a/app/assets/javascripts/markdown_editor.js.coffee
+++ b/app/assets/javascripts/markdown_editor.js.coffee
@@ -38,6 +38,7 @@ class @MarkdownEditor
 
   bindForm: ->
     @$form.on 'submit', (e) =>
+      console.log @editor.getSession().getValue()
       @$textarea.val @editor.getSession().getValue()
       return true
 

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -21,7 +21,13 @@ class BasePresenter
     options = {
       fenced_code_blocks: true,
       autolink: true,
-      space_after_headers: true
+      space_after_headers: true,
+      hightlight: true,
+      footnotes: true,
+      with_toc_data: true,
+      tables: true,
+      strikethrough: true,
+      no_styles: true
     }
     Redcarpet::Markdown.new(renderer, options).render(text).html_safe
   end

--- a/app/presenters/blog_presenter.rb
+++ b/app/presenters/blog_presenter.rb
@@ -3,7 +3,7 @@ require "html_truncate"
 class BlogPresenter < BasePresenter
 
   def content
-    markdown(@object.content)
+    h.find_and_preserve(markdown(@object.content)).html_safe
   end
 
   def author_link


### PR DESCRIPTION
@roblafeve FYI, it is `coffeescript` instead of `coffee` when defining the language in the code fences. I was wrong.
