### PR TITLE
Send emails via Gmail SMTP from contact form. closes #59

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'coffee-rails'
 gem 'uglifier'
 
 gem "redcarpet", "~> 3.0.0"
+gem 'active_attr'
 
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,9 @@ GEM
       erubis (~> 2.7.0)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
+    active_attr (0.8.2)
+      activemodel (>= 3.0.2, < 4.1)
+      activesupport (>= 3.0.2, < 4.1)
     activemodel (4.0.0)
       activesupport (= 4.0.0)
       builder (~> 3.1.0)
@@ -195,6 +198,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_attr
   acts-as-taggable-on (~> 2.4.1)
   carrierwave (~> 0.9.0)
   coffee-rails

--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -1,4 +1,23 @@
 class ContactController < ApplicationController
-  def index
+  def new
+    @message = Message.new
+  end
+
+  def create
+    @message = Message.new(params[:message])
+    if @message.valid?
+      # TODO send message here
+      ContactMailer.contact_email(@message).deliver
+      redirect_to root_url, notice: "Message sent! Thank you for contacting us."
+    else
+      render "new"
+    end
+  end
+private
+
+  def message_params
+    params.require(:message).permit(
+      :email, :name, :content
+    )
   end
 end

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -1,0 +1,9 @@
+class ContactMailer < ActionMailer::Base
+  default from: "no-reply@cremalab.com"
+  default to: "info@cremalab.com"
+
+  def contact_email(message)
+    @message = message
+    mail(from: @message.email, subject: 'From the website contact form')
+  end
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,11 @@
+class Message
+  include ActiveAttr::Model
+
+  attribute :name
+  attribute :email
+  attribute :content
+
+  validates_presence_of :name
+  validates_format_of :email, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i
+  validates_length_of :content, :maximum => 500
+end

--- a/app/views/contact/new.html.haml
+++ b/app/views/contact/new.html.haml
@@ -43,11 +43,22 @@
         .contactBlock-size-wrap-content.sub-brown
           .icon-instagram
 .layout-content.sub-narrow
-  %h2.sub-centered 
+  %h2.sub-centered
     Have more to say?
     %span.subHeading Use this handy form to start a conversation with us.
-  %form
-    %input{type: "text", placeholder: "My friends call me..."}
-    %input{type: "text", placeholder: "I respond to emails at..."}
-    %textarea{placeholder: "I’d like to talk about..."}
-    %input.button.sub-outline{type: "submit", value: "And Go!"}
+
+  = form_for @message, url: contact_path do |f|
+    - if @message.errors.any?
+      .error_messages
+        %h5
+          = pluralize(@message.errors.count, "error")
+          prohibited this message from being saved:
+        %p
+          %ul
+            - @message.errors.full_messages.each do |msg|
+              %li= msg
+
+    = f.text_field :name, placeholder: "My friends call me..."
+    = f.text_field :email, placeholder: "I respond to emails at..."
+    = f.text_area :content, :rows => 5, placeholder: "I’d like to talk about..."
+    = f.submit "And Go!", class: "button sub-outline"

--- a/app/views/contact_mailer/contact_email.html.haml
+++ b/app/views/contact_mailer/contact_email.html.haml
@@ -1,0 +1,10 @@
+!!!
+%html
+  %head
+    %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
+  %body
+    %h1
+      = @message.name
+      wants to talk
+    .message
+      = simple_format(@message.content)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,7 +14,7 @@ CremalabCom::Application.configure do
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -33,6 +33,15 @@ CremalabCom::Application.configure do
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
   config.assets.debug = false
+
+  config.action_mailer.smtp_settings = {
+    :address              => 'smtp.gmail.com',
+    :port                 => 587,
+    :user_name            => ENV['GMAIL_USERNAME'],
+    :password             => ENV['GMAIL_PASSWORD'],
+    :authentication       => :plain,
+    :enable_starttls_auto => true
+  }
 
   # config.assets.css_compressor = :yui
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,6 +54,15 @@ CremalabCom::Application.configure do
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 
+  config.action_mailer.smtp_settings = {
+    :address              => 'smtp.gmail.com',
+    :port                 => 587,
+    :user_name            => ENV['GMAIL_USERNAME'],
+    :password             => ENV['GMAIL_PASSWORD'],
+    :authentication       => :plain,
+    :enable_starttls_auto => true
+  }
+
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,11 +4,13 @@ CremalabCom::Application.routes.draw do
   get "images/create"
   get "images/destroy"
   root 'home#index'
-  get "contact" => 'contact#index'
   get "process" => 'process#index'
   get "logout" => "sessions#destroy", :as => "logout"
   get "login" => "sessions#new", :as => "login"
   get "signup" => "users#new", :as => "signup"
+
+  get "contact"  => 'contact#new'
+  post "contact" => 'contact#create'
 
   resources :sessions
   resources :users, path: 'team' do

--- a/test/mailers/contact_mailer_test.rb
+++ b/test/mailers/contact_mailer_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ContactMailerTest < ActionMailer::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- Message model is not ActiveRecord - doesn't save to DB
- GMAIL_USERNAME and GMAIL_PASSWORD need to be set as env variables
- Validates format of email address, message length is under 500 characters, and presence of a name.
