### PR TITLE
Blog Categories #107

### DIFF
--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -25,6 +25,11 @@ class BlogsController < ApplicationController
     render :index
   end
 
+  def categories
+    @categories = Blog.tag_counts
+    render :categories
+  end
+
 private
 
   def blog_user

--- a/app/helpers/blogs_helper.rb
+++ b/app/helpers/blogs_helper.rb
@@ -1,0 +1,3 @@
+module BlogsHelper
+  include ActsAsTaggableOn::TagsHelper
+end

--- a/app/views/blogs/categories.html.haml
+++ b/app/views/blogs/categories.html.haml
@@ -1,0 +1,13 @@
+- content_for :admin_actions do
+  = link_to 'New Blog Post', new_admin_user_blog_path(current_user), class: 'button'
+%header.layout-header.sub-blog
+  .layout-content
+    - title "Blog Categories"
+    %h1
+      = link_to "Blog", blogs_path
+      Categories
+
+.layout-content
+  .post-body
+    - tag_cloud(@categories, %w(tag1 tag2 tag3 tag4)) do |tag, css_class|
+      = link_to tag.name, blog_category_path(tag.name.downcase.parameterize), :class => css_class

--- a/app/views/blogs/index.html.haml
+++ b/app/views/blogs/index.html.haml
@@ -15,6 +15,7 @@
     - else
       - title "Blog"
       %h1 The things we learn.
+      %h5= link_to 'Blog Categories', blog_categories_path
 
 = render partial: "preview", collection: @blogs, as: :blog
 - content_for :content_footer do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,11 +17,14 @@ CremalabCom::Application.routes.draw do
   resources :users, path: 'team' do
     resources :blogs
   end
+
+  get 'blog/categories' => 'blogs#categories', as: 'blog_categories'
+
   resources :blogs, path: 'blog' do
     get 'page/:page', :action => :index, :on => :collection
   end
 
-  get 'blog/categories/:id' => 'blogs#category'
+  get 'blog/categories/:id' => 'blogs#category', as: 'blog_category'
 
   resources :works, path: 'work'
 


### PR DESCRIPTION
Route at `blog/categories` and `blog_categories_path` that renders blogs/categories.haml and displays a tag cloud. CSS classes for the tags are `tag1` through `tag4`. Check out the [acts_as_taggable_on](https://github.com/mbleigh/acts-as-taggable-on) [cloud calculations](https://github.com/mbleigh/acts-as-taggable-on#tag-cloud-calculations) section for documentation.
